### PR TITLE
Fix 3.3 release bugs that's related to EV & CM thumbnail

### DIFF
--- a/epe_dbresource_browser/epe_dbresource_browser.module
+++ b/epe_dbresource_browser/epe_dbresource_browser.module
@@ -117,6 +117,8 @@ function epe_dbresource_browser_preload() {
     'editmode'=>false,
   )),'setting');
 
+  drupal_add_js(array('theme_path'=>base_path() . drupal_get_path('theme','bootstrap')),'setting');
+
   drupal_add_css('http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css','external');
   drupal_add_css(drupal_get_path('module','epe_dbresource_browser') . '/css/epe_resource_browser.css');
   drupal_add_css(libraries_get_path('ngProgress') . '/ngProgress.css');

--- a/epe_ev/epe_ev.install
+++ b/epe_ev/epe_ev.install
@@ -287,3 +287,12 @@ function epe_ev_update_7004(&$sandbox) {
   $view_definition = epe_ev_views_default_views();
   views_save_view($view_definition['epe_ev_search_view']);
 }
+
+/**
+ * Post 3.3 release fix: fix epe_ev_search_view view's thumbnail field output code that calls the wrong field and the wrong image style type
+ */
+function epe_ev_update_7005(&$sandbox) {
+  module_load_include('inc','epe_ev','epe_ev.views_default');
+  $view_definition = epe_ev_views_default_views();
+  views_save_view($view_definition['epe_ev_search_view']);
+}

--- a/epe_ev/epe_ev.views_default.inc
+++ b/epe_ev/epe_ev.views_default.inc
@@ -183,11 +183,11 @@ function epe_ev_views_default_views() {
   $handler->display->display_options['fields']['php']['use_php_setup'] = 0;
   $handler->display->display_options['fields']['php']['php_output'] = '<?php
       $node = node_load($data->entity);
-      $image = field_get_items(\'node\', $node, \'ev_tool_thumbnail\');
-      $output = field_view_value(\'node\', $node, \'ev_tool_thumbnail\', $image[0], array(
+      $image = field_get_items(\'node\', $node, \'field_instance_thumbnail\');
+      $output = field_view_value(\'node\', $node, \'field_instance_thumbnail\', $image[0], array(
         \'type\' => \'image\',
         \'settings\' => array(
-           \'image_style\' => \'thumbnail\',
+           \'image_style\' => \'resource_browser_thumbnail\',
         ),
       ));
       echo render($output);


### PR DESCRIPTION
Add missing Drupal theme setting path in Drupal javascript setting.
Change epe_ev_search_view's thumbnail php code.  The thumbnail php code
is targeting the wrong field and using the wrong image style.
Add new update fuction to epe_ev to update epe_ev_search_view
