### PR TITLE
add missing user id when executing multimedia view on filtering external...

### DIFF
--- a/epe_dbmultimedia/inc/epe_dbmultimedia.rest.api.inc
+++ b/epe_dbmultimedia/inc/epe_dbmultimedia.rest.api.inc
@@ -16,6 +16,10 @@ function epe_dbmultimedia_restful_api() {
     $filter = $view->get_item($display_name, 'filter', 'author_uid');
     $filter['value'] = $user->uid;
     $view->set_item($display_name, 'filter', 'author_uid', $filter);
+
+    $filter = $view->get_item($display_name, 'filter', 'author_uid_1');
+    $filter['value'] = $user->uid;
+    $view->set_item($display_name, 'filter', 'author_uid_1', $filter);
   } else  {
     $filters = $view->display_handler->get_option('filters');
     unset($filters['author_uid']);

--- a/epe_dbresource_browser/inc/epe_dbresource_browser.rest.api.inc
+++ b/epe_dbresource_browser/inc/epe_dbresource_browser.rest.api.inc
@@ -45,6 +45,12 @@ function epe_dbresource_browser_pager_api() {
         $filter = $view->get_item($display_name, 'filter', 'author_uid');
         $filter['value'] = $user->uid;
         $view->set_item($display_name, 'filter', 'author_uid', $filter);
+
+        if($key == 'epe_dbmultimedia' || $key == 'epe_dbdocument') {
+          $filter = $view->get_item($display_name, 'filter', 'author_uid_1');
+          $filter['value'] = $user->uid;
+          $view->set_item($display_name, 'filter', 'author_uid_1', $filter);
+        }
       } else {
         $filters = $view->display_handler->get_option('filters');
         unset($filters['author_uid']);

--- a/epe_llb/epe_llb.install
+++ b/epe_llb/epe_llb.install
@@ -604,3 +604,15 @@ function epe_llb_update_7011(&$sandbox) {
     user_role_grant_permissions($role->rid,array('epe node clone api'));
   }
 }
+
+/**
+ * epedev release-3.4 fixes
+ * fix resource file field allowable file extension
+ */
+function epe_llb_update_7012(&$sandbox) {
+  $field_resource_file = field_info_instance('node', 'field_resource_file', 'llb_resource');
+  module_load_include('inc','epe_llb','inc/epe_llb.field_instance');
+  $field_instances = _epe_llb_field_default_field_instances();
+  $field_resource_file['settings']['file_extensions'] = $field_instances['node-llb_resource-field_resource_file']['settings']['file_extensions'];
+  field_update_instance($field_resource_file);
+}

--- a/epe_llb/epe_llb.module
+++ b/epe_llb/epe_llb.module
@@ -931,8 +931,8 @@ function epe_llb_reload_dataset($dataset, $assoc_resources) {
   if($dataset->nid != 'NULL') {
     $data = json_decode($assoc_resources[$dataset->nid]);
 
-    $dataset->thumbnail = '';
-    if(isset($data->thumbnail)): $dataset->thumbnail = $data->thumbnail; endif;
+    $dataset->thumbnail = base_path() . drupal_get_path('theme','bootstrap') . '/images/no_thumb_small.jpg';
+    if(isset($data->thumbnail) && $data->thumbnail != ''): $dataset->thumbnail = $data->thumbnail; endif;
     if(isset($data->uri)): $dataset->uri = $data->uri; endif;
     if(isset($data->file)): $dataset->file = $data->file; endif;
     if(isset($data->credit)): $dataset->credit = $data->credit; endif;

--- a/epe_llb/inc/epe_llb.field_instance.inc
+++ b/epe_llb/inc/epe_llb.field_instance.inc
@@ -1372,7 +1372,7 @@ function _epe_llb_field_default_field_instances() {
     'settings' => array(
       'description_field' => 0,
       'file_directory' => '',
-      'file_extensions' => 'doc docx pdf',
+      'file_extensions' => 'txt pdf doc docx ppt pptx xls xlsx',
       'filefield_paths' => array(
         'active_updating' => 0,
         'file_name' => array(

--- a/epe_llb/templates/epe_llb_field_slideshow.tpl.php
+++ b/epe_llb/templates/epe_llb_field_slideshow.tpl.php
@@ -12,7 +12,7 @@ if($images):
           <source src="<?php echo $slide->file; ?>">
         </video>
       <?php } elseif($slide->type == 'web_resource') { ?>
-      <a href="<?php echo base_path(); ?>node/<?php echo $slide->nid; ?>">
+      <a href="<?php echo base_path(); ?>node/<?php echo $slide->nid; ?>" target="_blank">
         <img src="<?php print $slide->thumbnail; ?>" alt="<?php print $slide->title; ?>" style="width:480px;">
       </a>
       <?php
@@ -25,7 +25,7 @@ if($images):
       echo $result[0][0];*/
       ?>
       <?php } else { ?>
-      <a href="<?php echo base_path(); ?>node/<?php echo $slide->nid; ?>">
+      <a href="<?php echo base_path(); ?>node/<?php echo $slide->nid; ?>" target="_blank">
       <?php
       if($slide->uri != '') {
         $slide_image = array('style_name' => 'llb_detail_view', 'path' => $slide->uri, 'alt' => '', 'title' => '');

--- a/epe_llb/templates/epe_llb_node_form.tpl.php
+++ b/epe_llb/templates/epe_llb_node_form.tpl.php
@@ -31,7 +31,7 @@
       $content = file_get_contents(drupal_get_path('module','epe_llb') . '/contents/instruction/instruction.html');
       if($content) {
         $dom = new domDocument;
-        $dom->loadHTML($content);
+        @$dom->loadHTML($content);
         $images = $dom->getElementsByTagName('img');
         foreach($images as $img) {
           $content = str_replace($img->getAttribute('src'), base_path() . drupal_get_path('module','epe_llb') . '/contents/instruction/' . basename($img->getAttribute('src')), $content);

--- a/epe_llb/templates/node--llb-resource--teaser.tpl.php
+++ b/epe_llb/templates/node--llb-resource--teaser.tpl.php
@@ -45,8 +45,8 @@
               try{
                 $thumbnail_node_info = json_decode($content['field_challenge_thumbnail']['#items'][0]['value']);
                 foreach($thumbnail_node_info as $info) {
-                  $node_info = epe_llb_dataset_query($info);
-                  $thumbnail = array('style_name' => 'llb_teaser_view', 'path' => $node_info->uri, 'alt' => '', 'title' => '', 'attributes' => array('class'=>'img-polaroid'));
+                  //$node_info = epe_llb_dataset_query($info);
+                  $thumbnail = array('style_name' => 'llb_teaser_view', 'path' => $thumbnail_node_info[0]->uri, 'alt' => '', 'title' => '', 'attributes' => array('class'=>'img-polaroid'));
                   echo theme('image_style', $thumbnail);
                 }
               } catch (exception $e) {

--- a/epe_llb/templates/node--llb-resource.tpl.php
+++ b/epe_llb/templates/node--llb-resource.tpl.php
@@ -160,7 +160,9 @@
     }
   }
 ?>
+
 <!-- cm specific js -->
+<!--
 <script type="text/javascript">
 function loadFlash() {
   // from the microwave science website
@@ -205,6 +207,7 @@ function giveXMLtoJS(value) {
   return;
 }
 </script>
+-->
 
 <?php foreach($datasets as $key => $dataset): ?>
 <div class="tab-pane" id="dataset<?php echo $key; ?>">
@@ -230,7 +233,8 @@ function giveXMLtoJS(value) {
       $field_out = render($field_cm_data);
   ?>
     <div style="border-bottom: 2px solid #338ea9;margin-bottom: 10px;">
-      <div id="flashcontent"><p>Please update your Flash Player</p></div>
+      <!-- <div id="flashcontent"><p>Please update your Flash Player</p></div> -->
+       <iframe width="100%" height="424" src="<?php echo base_path(); ?>/node/<?php echo $dataset->nid; ?>/cmembed" frameborder="0" allowfullscreen></iframe>
     </div>
     <textarea id="conceptMapContents" name="conceptMapContents" style="display: none; width:500px; height:100px;"><?php echo $field_out ?></textarea>
     <div class="clearfix"><a href="<?php echo base_path() ?>node/<?php echo $dataset->nid; ?>" class="pull-right">View Resource Page</a></div>


### PR DESCRIPTION
... web resource

add missing user id when executing pager call on filtering external web resource
update resource file field file extension setting
set default dataset thumbnail in DI to no thumbnail
set DI slideshow target to blank
when loading DI text description content, some special characters are not escaped, this does not cause the content loading to fail, so add @ to $dom->loadHTML function to suppress error message
change DI cover page thumbnail loading code to render the image directly rather than going through a processor function that screw up the thumbnail uri instead
change cm embed in DI to use iframe instead

the above fixes addressed the following:
* When you click on 'My Multimedia' this list shows more than the user's own videos, and includes ALL videos that were added via the URL
* Search retrieves videos that do not contain the keyword searched, and the "extra" results are always ones that were added via the URL method
* On the instructor notes section (when creating an investigation) the upload for a file attachment does not allow many of the listed filetypes
* The "cover" page of a completed lesson always has a broken image
* In slideshows, the documents have no placeholder, and are just white
* In slideshows, the resources open in the *same* window, should be in a new tab
* The second concept map added to the Exploration section still does not appear.