### PR TITLE
epedev-434-ay: Add support for "save as" on resource edit pages

### DIFF
--- a/epe_cm/epe_cm.module
+++ b/epe_cm/epe_cm.module
@@ -309,12 +309,21 @@ function epe_cm_form_alter (&$form, &$form_state, $form_id) {
     $form['#submit'] = array('cm_resource_node_form_submit_custom');
     $form['#attached']['js'][] = libraries_get_path('formSavior') . '/jquery.formSavior.min.js';
     $form['#attached']['js']['jQuery(document).ready(function($) { $("form#cm-resource-node-form").formSavior(); });'] = array( 'type' => 'inline');
+
+    if(is_numeric(arg(1))) {
+      $form['actions']['saveas'] = array(
+        '#type'=>'submit',
+        '#access'=>1,
+        '#value'=>t('Save As'),
+        '#weight'=>2,
+        '#submit'=>array(
+          'epe_cm_save_as_submit',
+          'cm_resource_node_form_submit_custom',
+        ),
+      );
+    }
   }
-
-
 }
-
-
 
 function cm_resource_node_form_submit_custom($form, &$form_state) {
   global $user;
@@ -361,7 +370,13 @@ function cm_resource_node_form_submit_custom($form, &$form_state) {
 
 }
 
-
-
-
-
+function epe_cm_save_as_submit($form, &$form_state) {
+  $form_state['node']->vid = '';
+  $form_state['node']->nid = '';
+  $form_state['node']->status = 0;
+  $form_state['node']->created = '';
+  $form_state['node']->changed = '';
+  $form_state['node']->is_new = 1;
+  $form_state['values']['nid'] = '';
+  $form_state['values']['vid'] = '';
+}

--- a/epe_dbaudio/epe_dbaudio.module
+++ b/epe_dbaudio/epe_dbaudio.module
@@ -128,7 +128,31 @@ function epe_dbaudio_form_alter(&$form, &$form_state, $form_id) {
     $form['#attached']['css'] = array(
       drupal_get_path('module', 'epe_dbaudio') . '/epe_dbaudio_form.css',
     );    
+
+    if(is_numeric(arg(1))) {
+      $form['actions']['saveas'] = array(
+        '#type'=>'submit',
+        '#access'=>1,
+        '#value'=>t('Save As'),
+        '#weight'=>2,
+        '#submit'=>array(      
+          'epe_dbaudio_save_as_submit',
+          'node_form_submit',
+        ),
+      );
+    }
   }
+}
+
+function epe_dbaudio_save_as_submit($form, &$form_state) {
+  $form_state['node']->vid = '';
+  $form_state['node']->nid = '';
+  $form_state['node']->status = 0;
+  $form_state['node']->created = '';
+  $form_state['node']->changed = '';
+  $form_state['node']->is_new = 1;
+  $form_state['values']['nid'] = '';
+  $form_state['values']['vid'] = '';
 }
 
 /*

--- a/epe_dbdocument/epe_dbdocument.module
+++ b/epe_dbdocument/epe_dbdocument.module
@@ -138,7 +138,31 @@ function epe_dbdocument_form_alter(&$form, &$form_state, $form_id) {
     $form['#attached']['css'] = array(
       drupal_get_path('module', 'epe_dbdocument') . '/epe_dbdocument_form.css',
     );    
+
+    if(is_numeric(arg(1))) {
+      $form['actions']['saveas'] = array(
+        '#type'=>'submit',
+        '#access'=>1,
+        '#value'=>t('Save As'),
+        '#weight'=>2,
+        '#submit'=>array(      
+          'epe_dbdocument_save_as_submit',
+          'node_form_submit',
+        ),
+      );
+    }
   }
+}
+
+function epe_dbdocument_save_as_submit($form, &$form_state) {
+  $form_state['node']->vid = '';
+  $form_state['node']->nid = '';
+  $form_state['node']->status = 0;
+  $form_state['node']->created = '';
+  $form_state['node']->changed = '';
+  $form_state['node']->is_new = 1;
+  $form_state['values']['nid'] = '';
+  $form_state['values']['vid'] = '';
 }
 
 /*

--- a/epe_dbimage/epe_dbimage.module
+++ b/epe_dbimage/epe_dbimage.module
@@ -137,7 +137,31 @@ function epe_dbimage_form_alter(&$form, &$form_state, $form_id) {
     $form['#attached']['css'] = array(
       drupal_get_path('module', 'epe_dbimage') . '/epe_dbimage_form.css',
     );
+
+    if(is_numeric(arg(1))) {
+      $form['actions']['saveas'] = array(
+        '#type'=>'submit',
+        '#access'=>1,
+        '#value'=>t('Save As'),
+        '#weight'=>2,
+        '#submit'=>array(      
+          'epe_dbimage_save_as_submit',
+          'node_form_submit',
+        ),
+      );
+    }
   }
+}
+
+function epe_dbimage_save_as_submit($form, &$form_state) {
+  $form_state['node']->vid = '';
+  $form_state['node']->nid = '';
+  $form_state['node']->status = 0;
+  $form_state['node']->created = '';
+  $form_state['node']->changed = '';
+  $form_state['node']->is_new = 1;
+  $form_state['values']['nid'] = '';
+  $form_state['values']['vid'] = '';
 }
 
 /*

--- a/epe_dbvideo/epe_dbvideo.module
+++ b/epe_dbvideo/epe_dbvideo.module
@@ -135,8 +135,32 @@ function epe_dbvideo_form_alter(&$form, &$form_state, $form_id) {
     
     $form['#attached']['css'] = array(
       drupal_get_path('module', 'epe_dbvideo') . '/epe_dbvideo_form.css',
-    );    
+    );
+
+    if(is_numeric(arg(1))) {
+      $form['actions']['saveas'] = array(
+        '#type'=>'submit',
+        '#access'=>1,
+        '#value'=>t('Save As'),
+        '#weight'=>2,
+        '#submit'=>array(      
+          'epe_dbvideo_save_as_submit',
+          'node_form_submit',
+        ),
+      );
+    }
   }
+}
+
+function epe_dbvideo_save_as_submit($form, &$form_state) {
+  $form_state['node']->vid = '';
+  $form_state['node']->nid = '';
+  $form_state['node']->status = 0;
+  $form_state['node']->created = '';
+  $form_state['node']->changed = '';
+  $form_state['node']->is_new = 1;
+  $form_state['values']['nid'] = '';
+  $form_state['values']['vid'] = '';
 }
 
 /*

--- a/epe_ev/epe_ev.module
+++ b/epe_ev/epe_ev.module
@@ -164,11 +164,35 @@ function epe_ev_form_alter(&$form, &$form_state, $form_id) {
     $form['field_source_nid']['#type'] = 'hidden';
     $form['#attached']['js'][] = libraries_get_path('formSavior') . '/jquery.formSavior.min.js';
     $form['#attached']['js']['jQuery(document).ready(function($) { $("form#ev-tool-instance-node-form").formSavior(); });'] = array( 'type' => 'inline');
+
+    if(is_numeric(arg(1))) {
+      $form['actions']['saveas'] = array(
+        '#type'=>'submit',
+        '#access'=>1,
+        '#value'=>t('Save As'),
+        '#weight'=>2,
+        '#submit'=>array(
+          'epe_ev_save_as_submit',
+          'node_form_submit',
+        ),
+      );
+    }
   }
 
   if($form_id == 'ev_tool_node_form') {
     $form['options']['status']['#type'] = 'hidden';
   }
+}
+
+function epe_ev_save_as_submit($form, &$form_state) {
+  $form_state['node']->vid = '';
+  $form_state['node']->nid = '';
+  $form_state['node']->status = 0;
+  $form_state['node']->created = '';
+  $form_state['node']->changed = '';
+  $form_state['node']->is_new = 1;
+  $form_state['values']['nid'] = '';
+  $form_state['values']['vid'] = '';
 }
 
 /*

--- a/epe_llb/epe_llb.module
+++ b/epe_llb/epe_llb.module
@@ -460,6 +460,20 @@ function epe_llb_form_llb_resource_node_form_alter(&$form, &$form_state, $form_i
 
   $form['options']['status']['#type'] = 'hidden';
 
+  if(is_numeric(arg(1))) {
+    $form['actions']['saveas'] = array(
+      '#type'=>'submit',
+      '#access'=>1,
+      '#value'=>t('Save As'),
+      '#weight'=>2,
+      '#submit'=>array(      
+        'epe_llb_save_as_submit',
+        'node_form_submit',
+        'epe_llb_custom_submission_handler',
+      ),
+    );
+  }
+
   //additional settings
   $form['fragment'] = array(
     '#type'=>'hidden',
@@ -470,9 +484,20 @@ function epe_llb_form_llb_resource_node_form_alter(&$form, &$form_state, $form_i
   $form['actions']['submit']['#submit'][] = 'epe_llb_custom_submission_handler';
 }
 
+function epe_llb_save_as_submit($form, &$form_state) {
+  $form_state['node']->vid = '';
+  $form_state['node']->nid = '';
+  $form_state['node']->status = 0;
+  $form_state['node']->created = '';
+  $form_state['node']->changed = '';
+  $form_state['node']->is_new = 1;
+  $form_state['values']['nid'] = '';
+  $form_state['values']['vid'] = '';
+}
+
 function epe_llb_custom_submission_handler($form, &$form_state) {
   unset($_GET['destination']);
-  if($form_state['clicked_button']['#id'] == 'edit-submit') {
+  if($form_state['clicked_button']['#id'] == 'edit-submit' || $form_state['clicked_button']['#id'] == 'edit-saveas') {
     $form_state['redirect'] = 'node/' . $form_state['nid'] . '/detail';
   }  
 }
@@ -659,13 +684,6 @@ function epe_llb_node_view_alter(&$build) {
     $datasets = json_decode($build['field_exploration_dataset']['#items'][0]['value']);
     if($datasets) {
       foreach($datasets as &$dataset) {
-        /*$data = $assoc_resources[$dataset->nid];
-        $dataset->thumbnail = '';
-        if(isset($data->thumbnail)): $dataset->thumbnail = $data->thumbnail; endif;
-        if(isset($data->uri)): $dataset->uri = $data->uri; endif;
-        if(isset($data->file)): $dataset->file = $data->file; endif;
-        $dataset->credit = $data->credit;
-        $dataset->source_url = $data->source_url;*/
         $dataset = epe_llb_reload_dataset($dataset, $assoc_resources);
       }
     }
@@ -675,13 +693,6 @@ function epe_llb_node_view_alter(&$build) {
     $intro_slideshow = json_decode($build['field_introductory_slideshow']['#items'][0]['value']);
     if($intro_slideshow) {
       foreach($intro_slideshow as &$dataset) {
-        /*$data = $assoc_resources[$dataset->nid];
-        $dataset->thumbnail = '';
-        if(isset($data->thumbnail)): $dataset->thumbnail = $data->thumbnail; endif;
-        if(isset($data->uri)): $dataset->uri = $data->uri; endif;
-        if(isset($data->file)): $dataset->file = $data->file; endif;
-        $dataset->credit = $data->credit;
-        $dataset->source_url = $data->source_url;*/
         $dataset = epe_llb_reload_dataset($dataset, $assoc_resources);
       }
     }
@@ -691,13 +702,6 @@ function epe_llb_node_view_alter(&$build) {
     $background_slideshow = json_decode($build['field_background_slideshow']['#items'][0]['value']);
     if($background_slideshow) {
       foreach($background_slideshow as &$dataset) {
-/*        $data = $assoc_resources[$dataset->nid];
-        $dataset->thumbnail = '';
-        if(isset($data->thumbnail)): $dataset->thumbnail = $data->thumbnail; endif;
-        if(isset($data->uri)): $dataset->uri = $data->uri; endif;
-        if(isset($data->file)): $dataset->file = $data->file; endif;
-        $dataset->credit = $data->credit;
-        $dataset->source_url = $data->source_url;*/
         $dataset = epe_llb_reload_dataset($dataset, $assoc_resources);
       }
     }
@@ -707,34 +711,12 @@ function epe_llb_node_view_alter(&$build) {
     $challenge_thumbnail = json_decode($build['field_challenge_thumbnail']['#items'][0]['value']);
     if($challenge_thumbnail) {
       foreach($challenge_thumbnail as &$dataset) {
-        /*$data = $assoc_resources[$dataset->nid];
-        $dataset->thumbnail = '';
-        if(isset($data->thumbnail)): $dataset->thumbnail = $data->thumbnail; endif;
-        if(isset($data->uri)): $dataset->uri = $data->uri; endif;
-        if(isset($data->file)): $dataset->file = $data->file; endif;
-        $dataset->credit = $data->credit;
-        $dataset->source_url = $data->source_url;*/
         $dataset = epe_llb_reload_dataset($dataset, $assoc_resources);
       }
     }
     $build['field_challenge_thumbnail']['#items'][0]['value'] = json_encode($challenge_thumbnail);
   }
 }
-
-/*
-function epe_llb_field_formatter_rebuild($form, &$form_state) {
-  //$form['field']['#prefix'] = 'This text will rule them all!';
-  //drupal_add_css('hello.css'); //This line works even after validation fails.
-
-  $form['field_background_question']['#title_display'] = 'invisible';
-  $form['field_background_question']['und']['#title_display'] = 'invisible';
-  $form['field_background_question']['und'][0]['value']['#title_display'] = 'invisible';
-  echo '<pre>';
-  print_r($form['field_background_question']);
-  echo '</pre>';
-  return $form;
-}
-*/
 
 function epe_llb_block_info() {
   $blocks['epe_llb_objectives_info'] = array(
@@ -831,30 +813,6 @@ function epe_llb_block_view($delta = '') {
 }
 
 function epe_llb_dataset_query($dataset) {
-/*  global $base_root;
-
-  $depend_modules = variable_get('EPE_CONTENT_MODULES',array());
-  //unset($depend_modules['epe_llb']);
-  $apiurl = $base_root . base_path() . 'api/resource/';
-
-  foreach($depend_modules as $key=>$module) {
-    if(isset($module['resource_browser'])) {
-      if( (isset($module['content_type']) && $module['content_type'] === $dataset->type) || (in_array($dataset->type, array('video_resource','audio_resource')) && $key === 'epe_dbmultimedia')) {
-        $apiurl .= $module['resource_browser']['api'] . '/';
-        break;
-      }
-    }
-  }
-  $apiurl .= $dataset->nid;
-
-  $ch = curl_init();
-  $timeout = 5;
-  curl_setopt($ch, CURLOPT_URL, $apiurl);
-  curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-  curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
-  $data = json_decode(curl_exec($ch));
-  curl_close($ch);*/
-
   $depend_modules = variable_get('EPE_CONTENT_MODULES',array());
 
   $current_module = '';

--- a/epe_web_resource/epe_web_resource.module
+++ b/epe_web_resource/epe_web_resource.module
@@ -106,7 +106,31 @@ function epe_web_resource_form_alter(&$form, &$form_state, $form_id) {
     $form['#attached']['js'] = array(
       drupal_get_path('module', 'epe_web_resource') . '/epe_web_resource_form.js',
     );
+
+    if(is_numeric(arg(1))) {
+      $form['actions']['saveas'] = array(
+        '#type'=>'submit',
+        '#access'=>1,
+        '#value'=>t('Save As'),
+        '#weight'=>2,
+        '#submit'=>array(      
+          'epe_web_resource_save_as_submit',
+          'node_form_submit',
+        ),
+      );
+    }
   }
+}
+
+function epe_web_resource_save_as_submit($form, &$form_state) {
+  $form_state['node']->vid = '';
+  $form_state['node']->nid = '';
+  $form_state['node']->status = 0;
+  $form_state['node']->created = '';
+  $form_state['node']->changed = '';
+  $form_state['node']->is_new = 1;
+  $form_state['values']['nid'] = '';
+  $form_state['values']['vid'] = '';
 }
 
 function epe_web_resource_origin_validate($form, &$form_state) {


### PR DESCRIPTION
add "save as" button to edit form only when it's a exsiting node
click save as will save existing node as a new node and redirect user to
the new node view page